### PR TITLE
2 build process

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,4 +32,4 @@ jobs:
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+      uses: advanced-security/maven-dependency-submission-action@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "2-build-process" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "master", "2-build-process" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/mdzip-base-maven-plugin"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/mdzip-process-sources-maven-plugin"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/mdzip-validate-maven-plugin"
+    schedule:
+      interval: "weekly"

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
         <configuration>
           <source>${maven.compiler.source}</source>
           <target>${maven.compiler.target}</target>


### PR DESCRIPTION
Correct build process by adding explicit versions for plugins and adding dependabot.yml file for all the submodules of maven
Closes #2 